### PR TITLE
Feat/#12/security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.h2database:h2'
+    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/sopt/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/domain/post/controller/PostController.java
@@ -11,11 +11,14 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.domain.post.dto.request.CreatePostRequest;
 import org.sopt.domain.post.dto.request.UpdatePostRequest;
 import org.sopt.domain.post.entity.BoardType;
+import org.sopt.global.common.response.GlobalErrorCode;
 import org.sopt.global.common.response.BaseResponse;
 import org.sopt.domain.post.dto.response.PostResponse;
 import org.sopt.global.common.response.GlobalSuccessCode;
 import org.sopt.domain.post.service.PostService;
+import org.sopt.global.exception.CustomException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,9 +36,11 @@ public class PostController {
     @ApiResponse(responseCode = "201", description = "게시글 생성 성공")
     @PostMapping
     public ResponseEntity<BaseResponse<PostResponse>> createPost(
+            Authentication authentication,
             @Valid @RequestBody CreatePostRequest request
     ) {
-        PostResponse response = postService.createPost(request);
+        // 인증된 userId로 작성자 지정
+        PostResponse response = postService.createPost(getAuthenticatedUserId(authentication), request);
         return BaseResponse.success(GlobalSuccessCode.CREATED, response);
     }
 
@@ -71,12 +76,14 @@ public class PostController {
     @ApiResponse(responseCode = "200", description = "수정 성공")
     @PutMapping("/{id}")
     public ResponseEntity<BaseResponse<PostResponse>> updatePost(
+            Authentication authentication,
             @Parameter(description = "수정할 게시글의 ID", example = "1")
             @PathVariable Long id,
 
             @Valid @RequestBody UpdatePostRequest updateRequest
     ) {
-        PostResponse post = postService.updatePost(id, updateRequest);
+        // 수정 요청자 검증은 Service에서 처리
+        PostResponse post = postService.updatePost(getAuthenticatedUserId(authentication), id, updateRequest);
         return BaseResponse.success(GlobalSuccessCode.UPDATED, post);
     }
 
@@ -84,10 +91,25 @@ public class PostController {
     @ApiResponse(responseCode = "200", description = "삭제 성공")
     @DeleteMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> deletePost(
+            Authentication authentication,
             @Parameter(description = "삭제할 게시글의 ID", example = "1")
             @PathVariable @Min(value = 1, message = "id는 1 이상이어야 합니다.") Long id
     ) {
-        postService.deletePost(id);
+        // 삭제 요청자 검증은 Service에서 처리
+        postService.deletePost(getAuthenticatedUserId(authentication), id);
         return BaseResponse.success(GlobalSuccessCode.DELETED);
+    }
+
+    private Long getAuthenticatedUserId(Authentication authentication) {
+        // JwtAuthFilter가 넣은 회원 id 꺼내기
+        if (authentication == null || authentication.getName() == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/org/sopt/domain/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/domain/post/dto/request/CreatePostRequest.java
@@ -20,10 +20,6 @@ public record CreatePostRequest(
         @Schema(description = "게시글 내용 (2000자 이내)", example = "게시글 내용입니다.")
         @NotBlank(message = "내용은 필수입니다.")
         @Size(max = 2000, message = "내용은 2000자 이내로 작성해주세요.")
-        String content,
-
-        @Schema(description = "작성자 ID", example = "1")
-        @NotNull(message = "작성자 ID는 필수입니다.")
-        Long userId
+        String content
 ) {
 }

--- a/src/main/java/org/sopt/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/domain/post/entity/Post.java
@@ -37,7 +37,13 @@ public class Post extends BaseTimeEntity {
     public String getContent() { return content; }
     public User getUser() { return user; }
 
+    public boolean isWrittenBy(Long userId) {
+        // 작성자 확인: 수정/삭제 권한 체크용
+        return user != null && user.getId().equals(userId);
+    }
+
     public void update(String title, String content) {
+        // 게시글 내용 변경
         this.title = title;
         this.content = content;
     }

--- a/src/main/java/org/sopt/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/org/sopt/domain/post/exception/PostErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 public enum PostErrorCode implements BaseErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND,"POST_404", "게시글을 찾을 수 없습니다."),
-    INVALID_POST_CONTENT(HttpStatus.BAD_REQUEST,"POST_400", "게시글 내용이 유효하지 않습니다.");
+    INVALID_POST_CONTENT(HttpStatus.BAD_REQUEST,"POST_400", "게시글 내용이 유효하지 않습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_403", "게시글에 대한 권한이 없습니다.");
 
     private final HttpStatus status;   // HttpStatus는 int를 사용하여 HttpStatus 의존 제거
     private final String code;

--- a/src/main/java/org/sopt/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/domain/post/service/PostService.java
@@ -22,18 +22,18 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserService userService;
 
-    // CREATE
+    // 게시글 생성: 요청 userId가 아니라 인증된 userId 사용
     @Transactional
-    public PostResponse createPost(CreatePostRequest request) {
+    public PostResponse createPost(Long userId, CreatePostRequest request) {
 
-        User user = userService.getUserById(request.userId());
+        User user = userService.getUserById(userId);
         Post post = new Post(request.boardType(), request.title(), request.content(), user);
 
         return new PostResponse(postRepository.save(post));
     }
 
 
-    // READ - 전체 목록 /  게시판 종류별 조회
+    // 게시글 목록: boardType 있으면 필터링, 없으면 전체 조회
     @Transactional(readOnly = true)
     public List<PostResponse> getAllPosts(BoardType boardType, int page, int size) {
 
@@ -50,7 +50,7 @@ public class PostService {
                 .toList();
     }
 
-    // READ - 상세
+    // 게시글 상세 조회
     @Transactional(readOnly = true)
     public PostResponse getPost(Long id) {
         Post post = postRepository.findById(id)
@@ -58,26 +58,37 @@ public class PostService {
             return new PostResponse(post);
     }
 
-    // UPDATE
+    // 게시글 수정: 작성자만 가능
     @Transactional
-    public PostResponse updatePost(Long id, UpdatePostRequest updateRequest) {
+    public PostResponse updatePost(Long userId, Long id, UpdatePostRequest updateRequest) {
 
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND, "게시글을 찾을 수 없습니다. id: " + id));
 
+        validateWriter(post, userId);
 
         post.update(updateRequest.title(), updateRequest.content());
 
-        return new PostResponse(postRepository.save(post));  // JPA의 영속성 컨텍스트 덕분에 사실 save() 안 해도 업데이트는 되지만, 인메모리에서는 save() 해줘야 업데이트가 반영된다.
+        // JPA는 save 없이도 반영되지만, 인메모리 저장소 호환용
+        return new PostResponse(postRepository.save(post));
     }
 
-    // DELETE
+    // 게시글 삭제: 작성자만 가능
     @Transactional
-    public void deletePost(Long id) {
+    public void deletePost(Long userId, Long id) {
 
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND, "게시글을 찾을 수 없습니다. id: " + id));
 
+        validateWriter(post, userId);
+
         postRepository.delete(post);
+    }
+
+    private void validateWriter(Post post, Long userId) {
+        // 인증된 회원과 게시글 작성자 비교
+        if (!post.isWrittenBy(userId)) {
+            throw new CustomException(PostErrorCode.POST_FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/org/sopt/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/org/sopt/domain/user/dto/request/SignUpRequest.java
@@ -16,6 +16,11 @@ public record SignUpRequest(
         @Schema(description = "사용자 이메일", example = "test@email.com")
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "유효한 이메일 형식이어야 합니다.")
-        String email
+        String email,
+
+        @Schema(description = "사용자 비밀번호", example = "Password123!")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        String password
 ) {
 }

--- a/src/main/java/org/sopt/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/org/sopt/domain/user/dto/response/UserResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.domain.user.entity.User;
 
 @Schema(description = "사용자 정보 응답 DTO")
 public record UserResponse(
@@ -14,4 +15,11 @@ public record UserResponse(
         @Schema(description = "사용자 이메일", example = "example@email.com")
         String email
 ) {
+        public static UserResponse from(User user) {
+                return new UserResponse(
+                        user.getId(),
+                        user.getNickname(),
+                        user.getEmail()
+                );
+        }
 }

--- a/src/main/java/org/sopt/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package org.sopt.domain.user.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.sopt.global.common.entity.BaseTimeEntity;
 
 @Entity
@@ -8,6 +9,7 @@ import org.sopt.global.common.entity.BaseTimeEntity;
         @UniqueConstraint(columnNames = "email"),
         @UniqueConstraint(columnNames = "nickname")
 })  // "user"는 SQL 예약어라 테이블명을 "users"로 변경
+@Getter
 public class User extends BaseTimeEntity {
 
     @Id
@@ -20,22 +22,15 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
+    private String password;
+
     protected User() {}
 
-    public User(String nickname, String email) {
+    public User(String nickname, String email, String password) {
         this.nickname = nickname;
         this.email = email;
+        this.password = password;
     }
 
-    public Long getId() {
-        return this.id;
-    }
-
-    public String getNickname() {
-        return this.nickname;
-    }
-
-    public String getEmail() {
-        return this.email;
-    }
 }

--- a/src/main/java/org/sopt/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/domain/user/entity/User.java
@@ -22,6 +22,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
+    // BCrypt로 암호화된 비밀번호
     @Column(nullable = false)
     private String password;
 

--- a/src/main/java/org/sopt/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/sopt/domain/user/repository/UserRepository.java
@@ -6,6 +6,8 @@ import org.sopt.domain.user.entity.User;
 public interface UserRepository {
     Optional<User> findById(Long id);
 
+    Optional<User> findByEmail(String email);
+
     User save(User user);
 
     boolean existsByEmail(String email);

--- a/src/main/java/org/sopt/domain/user/repository/jpa/SpringDataJpaUserRepository.java
+++ b/src/main/java/org/sopt/domain/user/repository/jpa/SpringDataJpaUserRepository.java
@@ -3,7 +3,11 @@ package org.sopt.domain.user.repository.jpa;
 import org.sopt.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SpringDataJpaUserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/sopt/domain/user/repository/jpa/UserJpaRepositoryAdapter.java
+++ b/src/main/java/org/sopt/domain/user/repository/jpa/UserJpaRepositoryAdapter.java
@@ -19,6 +19,11 @@ public class UserJpaRepositoryAdapter implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByEmail(String email) {
+        return jpaRepository.findByEmail(email);
+    }
+
+    @Override
     public User save(User user) {
         return jpaRepository.save(user);
     }

--- a/src/main/java/org/sopt/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/domain/user/service/UserService.java
@@ -31,7 +31,7 @@ public class UserService {
             throw new CustomException(UserErrorCode.USER_ALREADY_EXISTS, "이미 사용중인 닉네임입니다.");
         }
 
-        User user = new User(request.nickname(), request.email());
+        User user = new User(request.nickname(), request.email(), request.password());
 
         user = userRepository.save(user);
 

--- a/src/main/java/org/sopt/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import org.sopt.domain.user.entity.User;
 import org.sopt.domain.user.exception.UserErrorCode;
 import org.sopt.domain.user.repository.UserRepository;
 import org.sopt.global.exception.CustomException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,16 +15,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public User getUserById(Long id) {
+        // 내부 로직용 회원 조회
         return userRepository.findById(id)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND, "유저를 찾을 수 없습니다. id: " + id));
     }
 
     @Transactional
     public UserResponse signUp(SignUpRequest request) {
-        // 중복 확인
+        // 회원가입 중복 확인
         if (userRepository.existsByEmail(request.email())) {
             throw new CustomException(UserErrorCode.USER_ALREADY_EXISTS, "이미 사용중인 이메일입니다.");
         }
@@ -31,7 +34,8 @@ public class UserService {
             throw new CustomException(UserErrorCode.USER_ALREADY_EXISTS, "이미 사용중인 닉네임입니다.");
         }
 
-        User user = new User(request.nickname(), request.email(), request.password());
+        // 비밀번호는 BCrypt로 저장
+        User user = new User(request.nickname(), request.email(), passwordEncoder.encode(request.password()));
 
         user = userRepository.save(user);
 

--- a/src/main/java/org/sopt/security/AccessTokenBlacklist.java
+++ b/src/main/java/org/sopt/security/AccessTokenBlacklist.java
@@ -1,0 +1,34 @@
+package org.sopt.security;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccessTokenBlacklist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 1000)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private AccessTokenBlacklist(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public static AccessTokenBlacklist of(String token, LocalDateTime expiresAt) {
+        // 로그아웃된 Access Token 저장
+        return new AccessTokenBlacklist(token, expiresAt);
+    }
+}

--- a/src/main/java/org/sopt/security/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/security/JwtAuthFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.sopt.security.repository.AccessTokenBlacklistRepository;
 import org.sopt.security.service.JwtService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -22,6 +23,7 @@ import java.util.Collections;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
+    private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
 
     @Override
     protected void doFilterInternal(
@@ -31,18 +33,23 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (header != null && header.startsWith("Bearer ")) {
+            // Bearer 토큰만 꺼내서 검증
             String token = header.substring("Bearer ".length()).trim();
             try {
+                // 로그아웃된 Access Token이면 인증 처리 안 함
+                if (accessTokenBlacklistRepository.existsByToken(token)) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
+                // JWT 검증 성공: SecurityContext에 회원 id 저장
                 Long memberId = jwtService.verifyAndGetMemberId(token);
                 UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                         String.valueOf(memberId), null, Collections.emptyList());
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (IllegalArgumentException | JWTVerificationException e) {
-                // 유효하지 않은 토큰 또는 토큰이 없는 경우, 인증 없이 다음 필터로 넘겨요.
-                // 여기서 예외를 던지지 않는 이유는, /v1/login 같이 인증이 필요 없는 API도
-                // 이 필터를 거치기 때문이에요. 인증 여부 판단은 SecurityConfig의
-                // authorizeHttpRequests 설정에서 담당합니다.
+                // 잘못된 토큰: 인증 없이 통과, 최종 차단은 SecurityConfig가 처리
             }
         }
 

--- a/src/main/java/org/sopt/security/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/security/JwtAuthFilter.java
@@ -1,0 +1,51 @@
+package org.sopt.security;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sopt.security.service.JwtService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring("Bearer ".length()).trim();
+            try {
+                Long memberId = jwtService.verifyAndGetMemberId(token);
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                        String.valueOf(memberId), null, Collections.emptyList());
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (IllegalArgumentException | JWTVerificationException e) {
+                // 유효하지 않은 토큰 또는 토큰이 없는 경우, 인증 없이 다음 필터로 넘겨요.
+                // 여기서 예외를 던지지 않는 이유는, /v1/login 같이 인증이 필요 없는 API도
+                // 이 필터를 거치기 때문이에요. 인증 여부 판단은 SecurityConfig의
+                // authorizeHttpRequests 설정에서 담당합니다.
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/sopt/security/RefreshToken.java
+++ b/src/main/java/org/sopt/security/RefreshToken.java
@@ -41,7 +41,13 @@ public class RefreshToken {
     }
 
     public void rotate(String newToken, long expiresInSeconds) {
+        // 재발급 때 Refresh Token 교체
         this.token = newToken;
         this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSeconds);
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        // now와 같거나 이전이면 만료
+        return !expiresAt.isAfter(now);
     }
 }

--- a/src/main/java/org/sopt/security/RefreshToken.java
+++ b/src/main/java/org/sopt/security/RefreshToken.java
@@ -1,0 +1,47 @@
+package org.sopt.security;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private RefreshToken(Long memberId, String token, LocalDateTime expiresAt) {
+        this.memberId = memberId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public static RefreshToken of(Long memberId, String token, long expiresInSeconds) {
+        // 처음 저장: 현재 시각 기준 만료 시간 계산
+        return new RefreshToken(
+                memberId,
+                token,
+                LocalDateTime.now().plusSeconds(expiresInSeconds)
+        );
+    }
+
+    public void rotate(String newToken, long expiresInSeconds) {
+        this.token = newToken;
+        this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSeconds);
+    }
+}

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package org.sopt.security.config;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.security.JwtAuthFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/login",
+                                "/api/v1/auth/reissue",
+                                "/api/v1/users/signup",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/h2-console/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -41,5 +43,11 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // 비밀번호 단방향 암호화
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package org.sopt.security.config;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.security.JwtAuthFilter;
+import org.sopt.security.handler.CustomAccessDeniedHandler;
+import org.sopt.security.handler.CustomAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -21,14 +23,23 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                // JWT 방식이라 서버 세션/CSRF 사용 안 함
                 .csrf(csrf -> csrf.disable())
+                // H2 콘솔 화면 접근용
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 인증/인가 실패도 BaseResponse 형식으로 응답
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
+                        // 로그인/회원가입/문서/H2는 토큰 없이 허용
                         .requestMatchers(
                                 "/api/v1/auth/login",
                                 "/api/v1/auth/reissue",
@@ -38,9 +49,11 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/h2-console/**"
                         ).permitAll()
+                        // 게시글 조회는 공개, 쓰기/수정/삭제는 인증 필요
                         .requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                // Spring 기본 로그인 필터보다 먼저 JWT 검사
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/org/sopt/security/controller/AuthController.java
+++ b/src/main/java/org/sopt/security/controller/AuthController.java
@@ -12,6 +12,7 @@ import org.sopt.security.dto.request.LoginRequest;
 import org.sopt.security.dto.request.ReissueRequest;
 import org.sopt.security.dto.response.TokenResponse;
 import org.sopt.security.service.AuthService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -58,8 +59,12 @@ public class AuthController {
 
     @Operation(summary = "로그아웃 (Refresh Token 삭제)")
     @PostMapping("/logout")
-    public ResponseEntity<BaseResponse<Void>> logout(Authentication authentication) {
-        authService.logout(getAuthenticatedMemberId(authentication));
+    public ResponseEntity<BaseResponse<Void>> logout(
+            Authentication authentication,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization
+    ) {
+        // 로그아웃: 현재 Access Token 차단 + Refresh Token 삭제
+        authService.logout(getAuthenticatedMemberId(authentication), extractBearerToken(authorization));
 
         return BaseResponse.success(GlobalSuccessCode.SUCCESS);
     }
@@ -75,5 +80,13 @@ public class AuthController {
         } catch (NumberFormatException e) {
             throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
         }
+    }
+
+    private String extractBearerToken(String authorization) {
+        // Authorization: Bearer xxx 형식만 허용
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+        return authorization.substring("Bearer ".length()).trim();
     }
 }

--- a/src/main/java/org/sopt/security/controller/AuthController.java
+++ b/src/main/java/org/sopt/security/controller/AuthController.java
@@ -1,0 +1,45 @@
+package org.sopt.security.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.user.dto.response.UserResponse;
+import org.sopt.global.common.response.BaseResponse;
+import org.sopt.global.common.response.GlobalSuccessCode;
+import org.sopt.security.dto.response.TokenResponse;
+import org.sopt.security.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "로그인 (Access Token + Refresh Token 발급)")
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<TokenResponse>> login(
+            @RequestParam("email") String email,
+            @RequestParam("password") String password
+    ) {
+        TokenResponse tokens = authService.login(email, password);
+
+        return BaseResponse.success(GlobalSuccessCode.CREATED, tokens);
+    }
+
+    @Operation(summary = "내 정보 조회 (Access Token 검증)")
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse<UserResponse>> me(Authentication authentication) {
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalArgumentException("인증되지 않았습니다.");
+        }
+
+        Long memberId = Long.parseLong(authentication.getName());
+        UserResponse member = authService.getUserResponse(memberId);
+
+        return BaseResponse.success(GlobalSuccessCode.SUCCESS, member);
+    }
+}

--- a/src/main/java/org/sopt/security/controller/AuthController.java
+++ b/src/main/java/org/sopt/security/controller/AuthController.java
@@ -5,7 +5,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.user.dto.response.UserResponse;
 import org.sopt.global.common.response.BaseResponse;
+import org.sopt.global.common.response.GlobalErrorCode;
 import org.sopt.global.common.response.GlobalSuccessCode;
+import org.sopt.global.exception.CustomException;
 import org.sopt.security.dto.request.LoginRequest;
 import org.sopt.security.dto.request.ReissueRequest;
 import org.sopt.security.dto.response.TokenResponse;
@@ -47,13 +49,31 @@ public class AuthController {
     @GetMapping("/me")
     public ResponseEntity<BaseResponse<UserResponse>> me(Authentication authentication) {
 
-        if (authentication == null || authentication.getPrincipal() == null) {
-            throw new IllegalArgumentException("인증되지 않았습니다.");
-        }
-
-        Long memberId = Long.parseLong(authentication.getName());
+        // SecurityContext의 인증 id로 내 정보 조회
+        Long memberId = getAuthenticatedMemberId(authentication);
         UserResponse member = authService.getUserResponse(memberId);
 
         return BaseResponse.success(GlobalSuccessCode.SUCCESS, member);
+    }
+
+    @Operation(summary = "로그아웃 (Refresh Token 삭제)")
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout(Authentication authentication) {
+        authService.logout(getAuthenticatedMemberId(authentication));
+
+        return BaseResponse.success(GlobalSuccessCode.SUCCESS);
+    }
+
+    private Long getAuthenticatedMemberId(Authentication authentication) {
+        // 필터에서 넣은 principal 문자열을 Long id로 변환
+        if (authentication == null || authentication.getName() == null) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
+
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new CustomException(GlobalErrorCode.UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/org/sopt/security/controller/AuthController.java
+++ b/src/main/java/org/sopt/security/controller/AuthController.java
@@ -1,10 +1,13 @@
 package org.sopt.security.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.user.dto.response.UserResponse;
 import org.sopt.global.common.response.BaseResponse;
 import org.sopt.global.common.response.GlobalSuccessCode;
+import org.sopt.security.dto.request.LoginRequest;
+import org.sopt.security.dto.request.ReissueRequest;
 import org.sopt.security.dto.response.TokenResponse;
 import org.sopt.security.service.AuthService;
 import org.springframework.http.ResponseEntity;
@@ -21,10 +24,21 @@ public class AuthController {
     @Operation(summary = "로그인 (Access Token + Refresh Token 발급)")
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<TokenResponse>> login(
-            @RequestParam("email") String email,
-            @RequestParam("password") String password
+            @Valid @RequestBody LoginRequest request
     ) {
-        TokenResponse tokens = authService.login(email, password);
+        // 로그인: 이메일/비밀번호 확인 후 토큰 발급
+        TokenResponse tokens = authService.login(request.email(), request.password());
+
+        return BaseResponse.success(GlobalSuccessCode.CREATED, tokens);
+    }
+
+    @Operation(summary = "토큰 재발급 (Refresh Token 회전)")
+    @PostMapping("/reissue")
+    public ResponseEntity<BaseResponse<TokenResponse>> reissue(
+            @Valid @RequestBody ReissueRequest request
+    ) {
+        // 재발급: Refresh Token으로 새 토큰 묶음 발급
+        TokenResponse tokens = authService.reissue(request.refreshToken());
 
         return BaseResponse.success(GlobalSuccessCode.CREATED, tokens);
     }

--- a/src/main/java/org/sopt/security/dto/request/LoginRequest.java
+++ b/src/main/java/org/sopt/security/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package org.sopt.security.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/org/sopt/security/dto/request/ReissueRequest.java
+++ b/src/main/java/org/sopt/security/dto/request/ReissueRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.security.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueRequest(
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/org/sopt/security/dto/response/TokenResponse.java
+++ b/src/main/java/org/sopt/security/dto/response/TokenResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.security.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/sopt/security/exception/AuthErrorCode.java
+++ b/src/main/java/org/sopt/security/exception/AuthErrorCode.java
@@ -4,7 +4,10 @@ import org.sopt.global.common.response.BaseErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum AuthErrorCode implements BaseErrorCode {
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "이메일 또는 비밀번호가 올바르지 않습니다.");
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_002", "유효하지 않은 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_003", "Refresh Token이 만료되었습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_401_004", "Refresh Token을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/sopt/security/exception/AuthErrorCode.java
+++ b/src/main/java/org/sopt/security/exception/AuthErrorCode.java
@@ -1,0 +1,33 @@
+package org.sopt.security.exception;
+
+import org.sopt.global.common.response.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements BaseErrorCode {
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "이메일 또는 비밀번호가 올바르지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/sopt/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package org.sopt.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sopt.global.common.response.BaseResponse;
+import org.sopt.global.common.response.GlobalErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        // 권한 부족: 403을 공통 응답 형식으로 반환
+        response.setStatus(GlobalErrorCode.FORBIDDEN.getStatusNumber());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), BaseResponse.failure(GlobalErrorCode.FORBIDDEN).getBody());
+    }
+}

--- a/src/main/java/org/sopt/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package org.sopt.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sopt.global.common.response.BaseResponse;
+import org.sopt.global.common.response.GlobalErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        // 인증 실패: 401을 공통 응답 형식으로 반환
+        response.setStatus(GlobalErrorCode.UNAUTHORIZED.getStatusNumber());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), BaseResponse.failure(GlobalErrorCode.UNAUTHORIZED).getBody());
+    }
+}

--- a/src/main/java/org/sopt/security/repository/AccessTokenBlacklistRepository.java
+++ b/src/main/java/org/sopt/security/repository/AccessTokenBlacklistRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.security.repository;
+
+import org.sopt.security.AccessTokenBlacklist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccessTokenBlacklistRepository extends JpaRepository<AccessTokenBlacklist, Long> {
+    boolean existsByToken(String token);
+}

--- a/src/main/java/org/sopt/security/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/sopt/security/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.security.repository;
+
+import org.sopt.security.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/org/sopt/security/service/AuthService.java
+++ b/src/main/java/org/sopt/security/service/AuthService.java
@@ -89,6 +89,11 @@ public class AuthService {
         return TokenResponse.of(newAccessToken, newRefreshToken);
     }
 
+    @Transactional
+    public void logout(Long memberId) {
+        refreshTokenRepository.deleteByMemberId(memberId);
+    }
+
     public UserResponse getUserResponse(Long memberId) {
         // 인증된 id로 최신 회원 정보 조회
         User member = userRepository.findById(memberId)

--- a/src/main/java/org/sopt/security/service/AuthService.java
+++ b/src/main/java/org/sopt/security/service/AuthService.java
@@ -3,11 +3,15 @@ package org.sopt.security.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.user.dto.response.UserResponse;
 import org.sopt.domain.user.entity.User;
+import org.sopt.domain.user.exception.UserErrorCode;
 import org.sopt.domain.user.repository.UserRepository;
+import org.sopt.global.exception.CustomException;
 import org.sopt.security.RefreshToken;
 import org.sopt.security.dto.response.TokenResponse;
+import org.sopt.security.exception.AuthErrorCode;
 import org.sopt.security.repository.RefreshTokenRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,16 +22,19 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
     private long refreshTokenExpiresInSeconds;
 
     public UserResponse loginWithCredentials(String email, String password) {
+        // 로그인 검증: 이메일로 회원 조회
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_CREDENTIALS));
 
-        if (!user.getPassword().equals(password)) {
-            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        // 비밀번호 비교: 원문 vs BCrypt 해시
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new CustomException(AuthErrorCode.INVALID_CREDENTIALS);
         }
 
         return UserResponse.from(user);
@@ -51,7 +58,7 @@ public class AuthService {
 
     public UserResponse getUserResponse(Long memberId) {
         User member = userRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         return UserResponse.from(member);
     }
 }

--- a/src/main/java/org/sopt/security/service/AuthService.java
+++ b/src/main/java/org/sopt/security/service/AuthService.java
@@ -1,0 +1,57 @@
+package org.sopt.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.user.dto.response.UserResponse;
+import org.sopt.domain.user.entity.User;
+import org.sopt.domain.user.repository.UserRepository;
+import org.sopt.security.RefreshToken;
+import org.sopt.security.dto.response.TokenResponse;
+import org.sopt.security.repository.RefreshTokenRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtService jwtService;
+
+    @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
+    private long refreshTokenExpiresInSeconds;
+
+    public UserResponse loginWithCredentials(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        if (!user.getPassword().equals(password)) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public TokenResponse login(String email, String password) {
+        UserResponse member = loginWithCredentials(email, password);
+
+        String accessToken = jwtService.generateAccessToken(member.userId(), member.email());
+        String refreshToken = jwtService.generateRefreshToken(member.userId());
+
+        // 기존 Refresh Token 삭제 후 새로 저장
+        refreshTokenRepository.deleteByMemberId(member.userId());
+        refreshTokenRepository.save(
+                RefreshToken.of(member.userId(), refreshToken, refreshTokenExpiresInSeconds)
+        );
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    public UserResponse getUserResponse(Long memberId) {
+        User member = userRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        return UserResponse.from(member);
+    }
+}

--- a/src/main/java/org/sopt/security/service/AuthService.java
+++ b/src/main/java/org/sopt/security/service/AuthService.java
@@ -15,6 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -44,10 +46,11 @@ public class AuthService {
     public TokenResponse login(String email, String password) {
         UserResponse member = loginWithCredentials(email, password);
 
+        // 로그인 성공: Access/Refresh Token 발급
         String accessToken = jwtService.generateAccessToken(member.userId(), member.email());
         String refreshToken = jwtService.generateRefreshToken(member.userId());
 
-        // 기존 Refresh Token 삭제 후 새로 저장
+        // Refresh Token 교체: 한 회원당 하나만 유지
         refreshTokenRepository.deleteByMemberId(member.userId());
         refreshTokenRepository.save(
                 RefreshToken.of(member.userId(), refreshToken, refreshTokenExpiresInSeconds)
@@ -56,9 +59,49 @@ public class AuthService {
         return TokenResponse.of(accessToken, refreshToken);
     }
 
+    @Transactional
+    public TokenResponse reissue(String refreshTokenValue) {
+        // Refresh Token 검증: JWT 서명/만료 먼저 확인
+        Long memberId = verifyRefreshToken(refreshTokenValue);
+
+        // DB에 저장된 Refresh Token인지 확인
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        // 토큰 subject와 저장된 회원 id 비교
+        if (!refreshToken.getMemberId().equals(memberId)) {
+            throw new CustomException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        // DB 기준 만료 확인: 만료면 저장 토큰 삭제
+        if (refreshToken.isExpired(LocalDateTime.now())) {
+            refreshTokenRepository.deleteByMemberId(memberId);
+            throw new CustomException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        // 재발급 성공: Access 새로 발급, Refresh는 회전
+        UserResponse member = getUserResponse(memberId);
+        String newAccessToken = jwtService.generateAccessToken(member.userId(), member.email());
+        String newRefreshToken = jwtService.generateRefreshToken(member.userId());
+
+        refreshToken.rotate(newRefreshToken, refreshTokenExpiresInSeconds);
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+
     public UserResponse getUserResponse(Long memberId) {
+        // 인증된 id로 최신 회원 정보 조회
         User member = userRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         return UserResponse.from(member);
+    }
+
+    private Long verifyRefreshToken(String refreshTokenValue) {
+        try {
+            return jwtService.verifyAndGetMemberId(refreshTokenValue);
+        } catch (RuntimeException e) {
+            // JWT 라이브러리 예외를 우리 에러 코드로 변환
+            throw new CustomException(AuthErrorCode.INVALID_TOKEN);
+        }
     }
 }

--- a/src/main/java/org/sopt/security/service/AuthService.java
+++ b/src/main/java/org/sopt/security/service/AuthService.java
@@ -6,9 +6,11 @@ import org.sopt.domain.user.entity.User;
 import org.sopt.domain.user.exception.UserErrorCode;
 import org.sopt.domain.user.repository.UserRepository;
 import org.sopt.global.exception.CustomException;
+import org.sopt.security.AccessTokenBlacklist;
 import org.sopt.security.RefreshToken;
 import org.sopt.security.dto.response.TokenResponse;
 import org.sopt.security.exception.AuthErrorCode;
+import org.sopt.security.repository.AccessTokenBlacklistRepository;
 import org.sopt.security.repository.RefreshTokenRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +25,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
 
@@ -90,7 +93,13 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(Long memberId) {
+    public void logout(Long memberId, String accessToken) {
+        // 로그아웃: 남은 Access Token 시간만큼 블랙리스트 보관
+        LocalDateTime expiresAt = jwtService.verifyAndGetExpiresAt(accessToken);
+        if (!accessTokenBlacklistRepository.existsByToken(accessToken)) {
+            accessTokenBlacklistRepository.save(AccessTokenBlacklist.of(accessToken, expiresAt));
+        }
+        // Refresh Token 삭제: 재발급 차단
         refreshTokenRepository.deleteByMemberId(memberId);
     }
 

--- a/src/main/java/org/sopt/security/service/JwtService.java
+++ b/src/main/java/org/sopt/security/service/JwtService.java
@@ -1,0 +1,62 @@
+package org.sopt.security.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    private final Algorithm algorithm;
+    private final long accessTokenExpiresInSeconds;
+    private final long refreshTokenExpiresInSeconds;
+
+    public JwtService(
+            @Value("${security.jwt.secret}") String secret,
+            @Value("${security.jwt.access-token-expires-in-seconds:1800}") long accessTokenExpiresInSeconds,
+            @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}") long refreshTokenExpiresInSeconds
+    ) {
+        this.algorithm = Algorithm.HMAC256(secret);
+        this.accessTokenExpiresInSeconds = accessTokenExpiresInSeconds;
+        this.refreshTokenExpiresInSeconds = refreshTokenExpiresInSeconds;
+    }
+
+    public String generateAccessToken(Long memberId, String email) {
+        // Access Token: API 인증용, 짧게 사용
+        Instant now = Instant.now();
+        return JWT.create()
+                .withSubject(String.valueOf(memberId))
+                .withClaim("email", email)
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(now.plusSeconds(accessTokenExpiresInSeconds)))
+                .sign(algorithm);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        // Refresh Token: Access 재발급용, 길게 사용
+        Instant now = Instant.now();
+        return JWT.create()
+                .withSubject(String.valueOf(memberId))
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(now.plusSeconds(refreshTokenExpiresInSeconds)))
+                .sign(algorithm);
+    }
+
+    public Long verifyAndGetMemberId(String token) {
+        // 토큰 검증 후 subject를 회원 id로 사용
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("토큰이 없습니다.");
+        }
+        DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+        try {
+            return Long.parseLong(jwt.getSubject());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/org/sopt/security/service/JwtService.java
+++ b/src/main/java/org/sopt/security/service/JwtService.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 
 @Service
@@ -58,5 +60,17 @@ public class JwtService {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
         }
+    }
+
+    public LocalDateTime verifyAndGetExpiresAt(String token) {
+        // 로그아웃 블랙리스트 만료 시간 계산용
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("토큰이 없습니다.");
+        }
+        DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+        return jwt.getExpiresAt()
+                .toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ spring:
     password:
   h2:
     console:
-      enabled:true
+      enabled: true
   jpa:
     hibernate:
       ddl-auto: create
@@ -17,6 +17,11 @@ spring:
       hibernate:
         format_sql: true
 
+security:
+  jwt:
+    secret: ${JWT_SECRET:local-development-secret-change-before-deploy}
+    access-token-expires-in-seconds: 1800     # 30분
+    refresh-token-expires-in-seconds: 1209600 # 2주
 server:
   forward-headers-strategy: framework
 
@@ -27,5 +32,4 @@ app:
       - "https://sopt-38-castlekong.p-e.kr"
     allow-credentials: false
   swagger:
-    # 배포 환경에서 SWAGGER_SERVER_URL로 주입 권장 (예: https://sopt-38-castlekong.p-e.kr)
-    server-url: "https://sopt-38-castlekong.p-e.kr"
+    server-url: ${SWAGGER_SERVER_URL:}


### PR DESCRIPTION

# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] JWT + Spring Security 인증 적용
- [x] 로그인 / 토큰 재발급 API 구현
- [x] 비밀번호 BCrypt 암호화
- [x] 게시글 작성 / 수정 / 삭제 인증 적용
- [ ] 좋아요 인증 적용

<br>

### 심화 과제
- [x] 로그아웃 API 구현
- [x] Refresh Token 삭제
- [x] Access Token 블랙리스트 추가
- [ ] OAuth 로그인 구현

<br>

### **구현한 내용에 대해서 설명해주세요**

JWT랑 Spring Security 내용을 적용했습니다.

회원가입할 때 password를 추가했고, 비밀번호는 BCrypt로 암호화해서 저장하도록 했습니다.  
로그인하면 Access Token이랑 Refresh Token을 같이 발급하도록 했습니다.

게시글 작성이나 수정할 때  토큰에서 가져온 유저 id를 사용하도록 바꿨습니다.


<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

세미나에서는 Member 기준인데, 제 프로젝트는 User라서 User 기준으로 바꿨습니다.

응답을 제 프로젝트에 맞춰 response나 errorcode를 맞게 구현했습니다.

로그인 API를 LoginRequest를 만들어서 body로 받게 했습니다.  



<br>

---
### **키워드 과제 정리내용**

#### 
OAuth 2.0이란 무엇인가요? 인증 흐름을 정리해보세요.
--

- Google이나 Kakao 같은 외부 서비스로 로그인하는 방식 
- 서버가 사용자의 비밀번호를 직접 받는 게 아니라, 외부 서비스가 인증을 해주고 우리 서버는 유저 정보를 받아옴


1. 사용자가 Google 로그인 클릭
2. Google에서 로그인
3. Google이 우리 서버로 인증 결과를 보내줌
4. 우리 서버가 사용자 정보 조회
5. 우리 서버에서 JWT 발급


로그인 검사는 google에게 넘기고, 구글이 결과를 알려주면 거기에 맞는 사용자 정보를 내 서버에서 받아오고 JWT를 발급해준다.
로그인 검사만 google에게 위탁하는 것이다.


<br>

---

## 🚨 참고 사항